### PR TITLE
Remove the boost exception namespace hack

### DIFF
--- a/cross-build/ethereum/libethereum.sh
+++ b/cross-build/ethereum/libethereum.sh
@@ -20,13 +20,6 @@ section_configuring ${COMPONENT?}
 generic_hack \
   ${LIBETHEREUM_WORK_DIR?}/libethcore/CMakeLists.txt \
   '!/Eth::ethash-cl Cpuid/'
-generic_hack \
-  ${LIBETHEREUM_WORK_DIR?}/libethereum/ExtVM.cpp \
-  "{ \
-    gsub(/std::exception_ptr/,     \"boost::exception_ptr\"    ); \
-    gsub(/std::current_exception/, \"boost::current_exception\"); \
-    gsub(/std::rethrow_exception/, \"boost::rethrow_exception\"); \
-  }1"
 
 # ---------------------------------------------------------------------------
 set_cmake_paths "${JSONCPP?}:${BOOST?}:${LEVELDB?}:${CRYPTOPP?}:${GMP?}:${CURL?}:${LIBJSON_RPC_CPP?}:${MHD?}"


### PR DESCRIPTION
Which appears NOT to be required anymore.   I just did an armel build without this hack and it worked just fine.   The hack was done over a month ago, and might only have been required because of some other misconfiguration.